### PR TITLE
:bug: Fixes after the rebase on the Syncer refactoring

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -285,7 +285,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	}
 
 	logger.Info("Creating resource upsyncer")
-	upSyncer, err := upsync.NewUpSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, upstreamUpsyncerClusterClient, downstreamDynamicClient, ddsifForUpstreamSyncer, ddsifForUpstreamUpsyncer, ddsifForDownstream, syncTarget.GetUID())
+	upSyncer, err := upsync.NewUpSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, upstreamUpsyncerClusterClient, downstreamDynamicClient, ddsifForUpstreamUpsyncer, ddsifForDownstream, syncTarget.GetUID())
 	if err != nil {
 		return err
 	}

--- a/pkg/syncer/upsync/upsync_process_test.go
+++ b/pkg/syncer/upsync/upsync_process_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The KCP Authors.
+Copyright 2023 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,32 +19,30 @@ package upsync
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	kcpdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
-	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
-	kcpfakedynamic "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake"
-	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
-	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
+
+	kcpfakedynamic "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake"
+	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/informers"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/syncer/indexers"
 )
 
 var scheme *runtime.Scheme
@@ -52,7 +50,6 @@ var scheme *runtime.Scheme
 func init() {
 	scheme = runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
 }
 
 func toUnstructured(t require.TestingT, obj metav1.Object) *unstructured.Unstructured {
@@ -62,6 +59,56 @@ func toUnstructured(t require.TestingT, obj metav1.Object) *unstructured.Unstruc
 
 	return &result
 }
+
+var _ ddsif.GVRSource = (*mockedGVRSource)(nil)
+
+type mockedGVRSource struct {
+	upsyncer bool
+}
+
+func (s *mockedGVRSource) GVRs() map[schema.GroupVersionResource]ddsif.GVRPartialMetadata {
+	return map[schema.GroupVersionResource]ddsif.GVRPartialMetadata{
+		{
+			Version:  "v1",
+			Resource: "namespaces",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "namespace",
+				Kind:     "Namespace",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "persistentvolumes",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "persistentvolume",
+				Kind:     "PersistentVolume",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "pods",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "pod",
+				Kind:     "Pod",
+			},
+		},
+	}
+}
+
+func (s *mockedGVRSource) Ready() bool {
+	return true
+}
+
+func (s *mockedGVRSource) Subscribe() <-chan struct{} {
+	return make(<-chan struct{})
+}
+
 func TestUpsyncerprocess(t *testing.T) {
 	tests := map[string]struct {
 		fromNamespace *corev1.Namespace
@@ -85,38 +132,37 @@ func TestUpsyncerprocess(t *testing.T) {
 		"Upsyncer upsyncs namespaced resources": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
 				},
 			),
-			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
-			fromResource: getPVC("test-pvc", "test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			fromResource: createPod("test-pod", "test", "", map[string]string{
+				"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 				workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
 			}, nil, nil, "1"),
 			toResources:           []runtime.Object{},
-			resourceToProcessName: "test-pvc",
+			resourceToProcessName: "test-pod",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
-				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "test", toUnstructured(t, createPod("test-pod", "test", "", map[string]string{
+					"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "spec", "test",
-					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
-						"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "spec", "test",
+					toUnstructured(t, createPod("test-pod", "test", "", map[string]string{
+						"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 						workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
-					}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "status", "test",
-					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
-						"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "status", "test",
+					toUnstructured(t, createPod("test-pod", "test", "", map[string]string{
+						"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 						workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
-					}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
+					}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
 			},
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate, SpecUpdate},
@@ -125,31 +171,31 @@ func TestUpsyncerprocess(t *testing.T) {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace:          nil,
 			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
-			fromResource: getPV(getPVC("test", "test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			fromResource: createPV("test-pv", "", "", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":""}`,
-				}, nil, "1")),
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":""}`,
+				}, nil, "1"),
 			toResources:           []runtime.Object{},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
-				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "spec", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "status", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
+				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "", toUnstructured(t, createPV("test-pv", "", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "spec", "", toUnstructured(t, createPV("test-pv", "", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "status", "", toUnstructured(t, createPV("test-pv", "", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
 			},
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate},
@@ -158,33 +204,32 @@ func TestUpsyncerprocess(t *testing.T) {
 		"Status Syncer udpates namespaced resources": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
 				},
 			),
-			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
-			fromResource: getPVC("test-pvc", "test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			fromResource: createPod("test-pod", "test", "", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			}, nil, nil, "2"),
 			toResources: []runtime.Object{
-				getPVC("test-pvc", "test", "root:org:ws", map[string]string{
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"),
+				createPod("test-pod", "test", "root:org:ws", map[string]string{
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"),
 			},
-			resourceToProcessName: "test-pvc",
+			resourceToProcessName: "test-pod",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "metadata", "test",
-					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
-						"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-						workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-					}, map[string]string{"kcp.dev/resource-version": "2"}, nil, "2"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "metadata", "test",
+					toUnstructured(t, createPod("test-pod", "test", "", map[string]string{
+						"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+						workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}, map[string]string{"kcp.io/resource-version": "2"}, nil, "2"))),
 			},
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate},
@@ -193,30 +238,30 @@ func TestUpsyncerprocess(t *testing.T) {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace:          nil,
 			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
-			fromResource: getPV(getPVC("test", "test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			fromResource: createPV("test-pv", "", "", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":""}`,
-				}, nil, "2")),
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":""}`,
+				}, nil, "2"),
 			toResources: []runtime.Object{
-				getPV(getPVC("test", "test", "root:org:ws", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				createPV("test-pv", "", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 				}, map[string]string{
-					"kcp.dev/resource-version": "1",
-				}, nil, "1")),
+					"kcp.io/resource-version": "1",
+				}, nil, "1"),
 			},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "metadata", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "2"}, nil, "2")))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "metadata", "", toUnstructured(t, createPV("test-pv", "", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "2"}, nil, "2"))),
 			},
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate},
@@ -224,33 +269,33 @@ func TestUpsyncerprocess(t *testing.T) {
 		"StatusSyncer deletes upstream namespaced resources": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
 				},
 			),
-			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
 			fromResource: namespace("kcp-1dtzz0tyij19", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
 				},
 			),
 			toResources: []runtime.Object{
-				getPVC("test-pvc", "test", "root:org:ws", map[string]string{
-					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				createPod("test-pod", "test", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
 				}, nil, nil, "1"),
 			},
-			resourceToProcessName: "test-pvc",
+			resourceToProcessName: "test-pod",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
-				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
+				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
 			},
 			isUpstream: true,
 			updateType: []UpdateType{},
@@ -261,16 +306,16 @@ func TestUpsyncerprocess(t *testing.T) {
 			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
 			fromResource:           nil,
 			toResources: []runtime.Object{
-				getPV(getPVC("test", "test", "root:org:ws", map[string]string{
-					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				createPV("test-pv", "", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
-				}, nil, nil, "1")),
+				}, nil, nil, "1"),
 			},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
-				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
+				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "", "test-pv"),
 			},
 			isUpstream: true,
 			updateType: []UpdateType{},
@@ -283,12 +328,12 @@ func TestUpsyncerprocess(t *testing.T) {
 			defer cancel()
 			logger := klog.FromContext(ctx)
 
-			kcpLogicalCluster := logicalcluster.New(tc.upstreamLogicalCluster)
+			kcpLogicalCluster := logicalcluster.Name(tc.upstreamLogicalCluster)
 			if tc.syncTargetUID == "" {
 				tc.syncTargetUID = types.UID("syncTargetUID")
 			}
 			if tc.syncTargetWorkspace.Empty() {
-				tc.syncTargetWorkspace = logicalcluster.New("root:org:ws")
+				tc.syncTargetWorkspace = logicalcluster.Name("root:org:ws")
 			}
 
 			var allFromResources []runtime.Object
@@ -303,50 +348,103 @@ func TestUpsyncerprocess(t *testing.T) {
 			toClusterClient := kcpfakedynamic.NewSimpleDynamicClient(scheme, tc.toResources...)
 
 			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(tc.syncTargetWorkspace, tc.syncTargetName)
-			fromInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(fromClient, time.Hour, metav1.NamespaceAll, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
-			})
-			toInformers := kcpdynamicinformer.NewFilteredDynamicSharedInformerFactory(toClusterClient, time.Hour, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + syncTargetKey + "=" + "Upsync"
-			})
+
+			ddsifForUpstreamUpsyncer, err := ddsif.NewDiscoveringDynamicSharedInformerFactory(toClusterClient, nil, nil, &mockedGVRSource{true}, cache.Indexers{})
+			require.NoError(t, err)
+
+			ddsifForDownstream, err := ddsif.NewScopedDiscoveringDynamicSharedInformerFactory(fromClient, nil,
+				func(o *metav1.ListOptions) {
+					o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
+				},
+				&mockedGVRSource{},
+				cache.Indexers{
+					indexers.ByNamespaceLocatorIndexName: indexers.IndexByNamespaceLocator,
+				},
+			)
+			require.NoError(t, err)
+
+			var cacheSyncsForAlwaysRequiredGVRs []cache.InformerSynced
+			if informer, err := ddsifForUpstreamUpsyncer.ForResource(corev1.SchemeGroupVersion.WithResource("namespaces")); err != nil {
+				require.NoError(t, err)
+			} else {
+				cacheSyncsForAlwaysRequiredGVRs = append(cacheSyncsForAlwaysRequiredGVRs, informer.Informer().HasSynced)
+			}
+			if informer, err := ddsifForDownstream.ForResource(corev1.SchemeGroupVersion.WithResource("namespaces")); err != nil {
+				require.NoError(t, err)
+			} else {
+				cacheSyncsForAlwaysRequiredGVRs = append(cacheSyncsForAlwaysRequiredGVRs, informer.Informer().HasSynced)
+			}
 
 			setupServersideApplyPatchReactor(toClusterClient)
-			fromClientResourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, fromClient)
-			toClientResourceWatcherStarted := setupClusterWatchReactor(tc.gvr.Resource, toClusterClient)
-
-			fakeInformers := newFakeSyncerInformers(tc.gvr, toInformers, fromInformers)
+			fromClientResourceWatcherStarted := setupWatchReactor(t, tc.gvr.Resource, fromClient)
+			toClientResourceWatcherStarted := setupClusterWatchReactor(t, tc.gvr.Resource, toClusterClient)
 
 			// upstream => to (kcp)
 			// downstream => from (physical cluster)
 			// to === kcp
 			// from === physiccal
-			controller, err := NewUpSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, toClusterClient, fromClient, toInformers, fromInformers, fakeInformers, tc.syncTargetUID)
-
+			controller, err := NewUpSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, toClusterClient, fromClient, ddsifForUpstreamUpsyncer, ddsifForDownstream, tc.syncTargetUID)
 			require.NoError(t, err)
 
-			toInformers.ForResource(tc.gvr).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
+			gvrsUpdated := make(chan struct{})
+			upstreamUpsyncerDDSIFUpdated := ddsifForUpstreamUpsyncer.Subscribe("upstreamUpsyncer")
+			downstreamDDSIFUpdated := ddsifForDownstream.Subscribe("downstream")
+			go func() {
+				<-upstreamUpsyncerDDSIFUpdated
+				t.Logf("%s: upstream ddsif synced", t.Name())
+				<-downstreamDDSIFUpdated
+				t.Logf("%s: downstream ddsif synced", t.Name())
 
-			fromInformers.Start(ctx.Done())
-			toInformers.Start(ctx.Done())
+				_, unsynced := ddsifForUpstreamUpsyncer.Informers()
+				for _, gvr := range unsynced {
+					informer, _ := ddsifForUpstreamUpsyncer.ForResource(gvr)
+					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)
+					t.Logf("%s: upstream ddsif informer synced for gvr %s", t.Name(), gvr.String())
+				}
+				_, unsynced = ddsifForDownstream.Informers()
+				for _, gvr := range unsynced {
+					informer, _ := ddsifForDownstream.ForResource(gvr)
+					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)
+					t.Logf("%s: downstream ddsif informer synced for gvr %s", t.Name(), gvr.String())
+				}
+				t.Logf("%s: gvrs updated", t.Name())
+				gvrsUpdated <- struct{}{}
+			}()
 
-			fromInformers.WaitForCacheSync(ctx.Done())
-			toInformers.WaitForCacheSync(ctx.Done())
+			ddsifForUpstreamUpsyncer.Start(ctx.Done())
+			ddsifForDownstream.Start(ctx.Done())
+
+			go ddsifForUpstreamUpsyncer.StartWorker(ctx)
+			go ddsifForDownstream.StartWorker(ctx)
 
 			<-fromClientResourceWatcherStarted
 			<-toClientResourceWatcherStarted
 
+			cache.WaitForCacheSync(ctx.Done(), cacheSyncsForAlwaysRequiredGVRs...)
+
+			<-gvrsUpdated
+
 			fromClient.ClearActions()
 			toClusterClient.ClearActions()
 
-			var key string
+			obj := &metav1.ObjectMeta{
+				Name: tc.resourceToProcessName,
+			}
+
 			if tc.fromNamespace != nil {
-				key = tc.fromNamespace.Name + "/" + tc.resourceToProcessName
-			} else {
-				key = tc.resourceToProcessName
+				obj.Namespace = tc.fromNamespace.Name
 			}
+
+			var key string
 			if tc.isUpstream {
-				key += "#" + kcpLogicalCluster.String()
+				obj.Annotations = map[string]string{
+					logicalcluster.AnnotationKey: kcpLogicalCluster.String(),
+				}
+				key, err = getKey(obj, Upstream)
+			} else {
+				key, err = getKey(obj, Downstream)
 			}
+			require.NoError(t, err)
 
 			err = controller.process(context.Background(), tc.gvr, key, tc.isUpstream, tc.updateType)
 			if tc.expectError {
@@ -355,40 +453,13 @@ func TestUpsyncerprocess(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Empty(t, cmp.Diff(tc.expectActionsOnFrom, fromClient.Actions()))
-			assert.Empty(t, cmp.Diff(tc.expectActionsOnTo, toClusterClient.Actions(), cmp.AllowUnexported(logicalcluster.Name{})))
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnTo, toClusterClient.Actions()))
 		})
 	}
 }
 
-type fakeSyncerInformers struct {
-	upstreamInformer   kcpkubernetesinformers.GenericClusterInformer
-	downStreamInformer informers.GenericInformer
-}
-
-func newFakeSyncerInformers(gvr schema.GroupVersionResource, upstreamInformers kcpdynamicinformer.DynamicSharedInformerFactory, downStreamInformers dynamicinformer.DynamicSharedInformerFactory) *fakeSyncerInformers {
-	return &fakeSyncerInformers{
-		upstreamInformer:   upstreamInformers.ForResource(gvr),
-		downStreamInformer: downStreamInformers.ForResource(gvr),
-	}
-}
-
-func (f *fakeSyncerInformers) AddUpstreamEventHandler(handler resourcesync.ResourceEventHandlerPerGVR) {
-}
-func (f *fakeSyncerInformers) AddDownstreamEventHandler(handler resourcesync.ResourceEventHandlerPerGVR) {
-}
-func (f *fakeSyncerInformers) InformerForResource(gvr schema.GroupVersionResource) (*resourcesync.SyncerInformer, bool) {
-	return &resourcesync.SyncerInformer{
-		UpstreamInformer:   f.upstreamInformer,
-		DownstreamInformer: f.downStreamInformer,
-	}, true
-}
-func (f *fakeSyncerInformers) Start(ctx context.Context, numThreads int) {}
-func (f *fakeSyncerInformers) SyncableGVRs() (map[schema.GroupVersionResource]*resourcesync.SyncerInformer, error) {
-	gvrs := map[schema.GroupVersionResource]*resourcesync.SyncerInformer{{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}: nil, {Group: "", Version: "v1", Resource: "persistentvolumes"}: nil}
-	return gvrs, nil
-}
-
-func setupWatchReactor(resource string, client *dynamicfake.FakeDynamicClient) chan struct{} {
+func setupWatchReactor(t *testing.T, resource string, client *dynamicfake.FakeDynamicClient) chan struct{} {
+	t.Helper()
 	watcherStarted := make(chan struct{})
 	client.PrependWatchReactor(resource, func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -397,23 +468,31 @@ func setupWatchReactor(resource string, client *dynamicfake.FakeDynamicClient) c
 		if err != nil {
 			return false, nil, err
 		}
+		t.Logf("%s: watcher started", t.Name())
 		close(watcherStarted)
 		return true, watch, nil
 	})
 	return watcherStarted
 }
 
-func setupClusterWatchReactor(resource string, client *kcpfakedynamic.FakeDynamicClusterClientset) chan struct{} {
+func setupClusterWatchReactor(t *testing.T, resource string, client *kcpfakedynamic.FakeDynamicClusterClientset) chan struct{} {
+	t.Helper()
 	watcherStarted := make(chan struct{})
-	client.PrependWatchReactor(resource, func(action kcptesting.Action) (handled bool, ret watch.Interface, err error) {
+	client.PrependWatchReactor(resource, func(action kcptesting.Action) (bool, watch.Interface, error) {
+		cluster := action.GetCluster()
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
-		watch, err := client.Tracker().Watch(gvr, ns)
-		if err != nil {
-			return false, nil, err
+		var watcher watch.Interface
+		var err error
+		switch cluster {
+		case logicalcluster.Wildcard:
+			watcher, err = client.Tracker().Watch(gvr, ns)
+		default:
+			watcher, err = client.Tracker().Cluster(cluster).Watch(gvr, ns)
 		}
+		t.Logf("%s: cluster watcher started", t.Name())
 		close(watcherStarted)
-		return true, watch, nil
+		return true, watcher, err
 	})
 	return watcherStarted
 }
@@ -445,13 +524,13 @@ func namespace(name, clusterName string, labels, annotations map[string]string) 
 	}
 }
 
-func getPVC(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string, resourceVersion string) *corev1.PersistentVolumeClaim {
+func createPV(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string, resourceVersion string) *corev1.PersistentVolume {
 	if clusterName != "" {
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
 		annotations[logicalcluster.AnnotationKey] = clusterName
-		return &corev1.PersistentVolumeClaim{
+		return &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				ResourceVersion: resourceVersion,
 				Name:            name,
@@ -462,7 +541,7 @@ func getPVC(name, namespace, clusterName string, labels, annotations map[string]
 			},
 		}
 	}
-	return &corev1.PersistentVolumeClaim{
+	return &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: resourceVersion,
 			Name:            name,
@@ -472,17 +551,33 @@ func getPVC(name, namespace, clusterName string, labels, annotations map[string]
 			Finalizers:      finalizers,
 		},
 	}
-
 }
 
-func getPV(pvc *corev1.PersistentVolumeClaim) *corev1.PersistentVolume {
-	return &corev1.PersistentVolume{
+func createPod(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string, resourceVersion string) *corev1.Pod {
+	if clusterName != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: resourceVersion,
+				Name:            name,
+				Namespace:       namespace,
+				Labels:          labels,
+				Annotations:     annotations,
+				Finalizers:      finalizers,
+			},
+		}
+	}
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			ResourceVersion: pvc.GetResourceVersion(),
-			Name:            pvc.GetName() + "-pv",
-			Labels:          pvc.GetLabels(),
-			Annotations:     pvc.GetAnnotations(),
-			Finalizers:      pvc.GetFinalizers(),
+			ResourceVersion: resourceVersion,
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			Annotations:     annotations,
+			Finalizers:      finalizers,
 		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fixes after the rebase on the Syncer refactoring

## Disclaimer

Still to be done after this PR is merged to https://github.com/kcp-dev/kcp/pull/2214 :
- Cleanup the logic that creates / updates the resource in upstream: updating the `spec` sub-resource doesn't make sense.
- Rebase on top of main